### PR TITLE
feat:프론트 연동을 위한 임시 재료 API 설계

### DIFF
--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/controller/IngredientDevController.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/controller/IngredientDevController.java
@@ -1,0 +1,126 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.controller;
+
+import com.inforsion.inforsionserver.domain.ingredient_dev.dto.request.IngredientDevCreateRequest;
+import com.inforsion.inforsionserver.domain.ingredient_dev.dto.request.IngredientDevUpdateRequest;
+import com.inforsion.inforsionserver.domain.ingredient_dev.dto.response.IngredientDevResponse;
+import com.inforsion.inforsionserver.domain.ingredient_dev.service.IngredientDevService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Ingredient Dev", description = "재료 관리 신규 API - 단일 재료 등록")
+@RestController
+@RequestMapping("/api/v1/ingredient-dev")
+@RequiredArgsConstructor
+public class IngredientDevController {
+
+    private final IngredientDevService ingredientDevService;
+
+    @Operation(
+            summary = "재료 등록",
+            description = "재료명, 재고 가격, 1개당 재고 용량, 재고 수를 등록합니다. 이미지 업로드는 추후 활성화 예정입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "재료 등록 성공",
+                    content = @Content(schema = @Schema(implementation = IngredientDevResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 오류",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "중복된 재료명",
+                    content = @Content
+            )
+    })
+    @PostMapping
+    public ResponseEntity<IngredientDevResponse> createIngredient(
+            @Parameter(description = "재료 등록 요청 데이터", required = true)
+            @Valid @RequestBody IngredientDevCreateRequest request
+            // @RequestPart(value = "image", required = false) MultipartFile imageFile
+    ) {
+        IngredientDevResponse response = ingredientDevService.createIngredient(request /*, imageFile */);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "재료 단건 조회")
+    @GetMapping("/{ingredientId}")
+    public ResponseEntity<IngredientDevResponse> getIngredient(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId
+    ) {
+        return ResponseEntity.ok(ingredientDevService.getIngredient(ingredientId));
+    }
+
+    @Operation(summary = "재료 수정", description = "필요한 필드만 부분 수정 가능합니다.")
+    @PutMapping("/{ingredientId}")
+    public ResponseEntity<IngredientDevResponse> updateIngredient(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId,
+            @Parameter(description = "수정 요청 데이터", required = true)
+            @Valid @RequestBody IngredientDevUpdateRequest request
+    ) {
+        IngredientDevResponse response = ingredientDevService.updateIngredient(ingredientId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "재료 삭제", description = "이미지는 별도 관리 정책에 따라 S3 정리하지 않습니다.")
+    @DeleteMapping("/{ingredientId}")
+    public ResponseEntity<Void> deleteIngredient(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId
+    ) {
+        ingredientDevService.deleteIngredient(ingredientId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "재료 이미지 업로드", description = "ingredients-dev 경로로 S3에 업로드합니다.")
+    @PostMapping(value = "/{ingredientId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<IngredientDevResponse> uploadImage(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId,
+            @Parameter(description = "업로드할 이미지", required = true) @RequestPart("image") MultipartFile imageFile
+    ) {
+        IngredientDevResponse response = ingredientDevService.uploadImage(ingredientId, imageFile);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "재료 이미지 수정", description = "기존 이미지를 삭제하고 새 파일을 업로드합니다.")
+    @PutMapping(value = "/{ingredientId}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<IngredientDevResponse> updateImage(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId,
+            @Parameter(description = "새 이미지", required = true) @RequestPart("image") MultipartFile imageFile
+    ) {
+        IngredientDevResponse response = ingredientDevService.updateImage(ingredientId, imageFile);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "재료 이미지 조회", description = "S3 URL을 반환합니다. 이미지가 없으면 404를 반환합니다.")
+    @GetMapping("/{ingredientId}/image")
+    public ResponseEntity<IngredientDevResponse> getImage(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId
+    ) {
+        IngredientDevResponse response = ingredientDevService.getImage(ingredientId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "재료 이미지 삭제", description = "S3에서 파일을 삭제하고 DB의 이미지 URL을 비웁니다.")
+    @DeleteMapping("/{ingredientId}/image")
+    public ResponseEntity<Void> deleteImage(
+            @Parameter(description = "재료 ID", required = true) @PathVariable Integer ingredientId
+    ) {
+        ingredientDevService.deleteImage(ingredientId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/dto/request/IngredientDevCreateRequest.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/dto/request/IngredientDevCreateRequest.java
@@ -1,0 +1,33 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IngredientDevCreateRequest {
+
+    @NotBlank(message = "재료명은 필수입니다.")
+    private String name;
+
+    @NotNull(message = "재고 가격은 필수입니다.")
+    @Positive(message = "재고 가격은 0보다 커야 합니다.")
+    private BigDecimal stockPrice;
+
+    @NotNull(message = "1개당 재고 용량은 필수입니다.")
+    @Positive(message = "1개당 재고 용량은 0보다 커야 합니다.")
+    private BigDecimal unitCapacity;
+
+    @NotNull(message = "재고 수는 필수입니다.")
+    @Positive(message = "재고 수는 0보다 커야 합니다.")
+    private Integer stockQuantity;
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/dto/request/IngredientDevUpdateRequest.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/dto/request/IngredientDevUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IngredientDevUpdateRequest {
+
+    @Size(min = 1, max = 100, message = "재료명은 1~100자여야 합니다.")
+    private String name;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "재고 가격은 0보다 커야 합니다.")
+    @Digits(integer = 12, fraction = 2, message = "재고 가격은 소수점 2자리까지 입력 가능합니다.")
+    private BigDecimal stockPrice;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "1개당 재고 용량은 0보다 커야 합니다.")
+    @Digits(integer = 10, fraction = 2, message = "1개당 재고 용량은 소수점 2자리까지 입력 가능합니다.")
+    private BigDecimal unitCapacity;
+
+    @Positive(message = "재고 수는 0보다 커야 합니다.")
+    private Integer stockQuantity;
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/dto/response/IngredientDevResponse.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/dto/response/IngredientDevResponse.java
@@ -1,0 +1,34 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.dto.response;
+
+import com.inforsion.inforsionserver.domain.ingredient_dev.entity.IngredientDevEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class IngredientDevResponse {
+    private final Integer id;
+    private final String name;
+    private final BigDecimal stockPrice;
+    private final BigDecimal unitCapacity;
+    private final Integer stockQuantity;
+    private final String imageUrl;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static IngredientDevResponse from(IngredientDevEntity entity) {
+        return IngredientDevResponse.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .stockPrice(entity.getStockPrice())
+                .unitCapacity(entity.getUnitCapacity())
+                .stockQuantity(entity.getStockQuantity())
+                .imageUrl(entity.getImageUrl())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/entity/IngredientDevEntity.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/entity/IngredientDevEntity.java
@@ -1,0 +1,66 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ingredients_dev")
+// Dedicated schema for the dev ingredient flow; intentionally separate from the legacy ingredients table.
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class IngredientDevEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ingredient_dev_id")
+    private Integer id;
+
+    @Column(name = "ingredient_dev_name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "dev_stock_price", precision = 12, scale = 2, nullable = false)
+    private BigDecimal stockPrice;
+
+    @Column(name = "dev_unit_capacity", precision = 10, scale = 2, nullable = false)
+    private BigDecimal unitCapacity;
+
+    @Column(name = "dev_stock_quantity", nullable = false)
+    private Integer stockQuantity;
+
+    @Column(name = "dev_image_url")
+    private String imageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void update(String name, BigDecimal stockPrice, BigDecimal unitCapacity, Integer stockQuantity) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (stockPrice != null) {
+            this.stockPrice = stockPrice;
+        }
+        if (unitCapacity != null) {
+            this.unitCapacity = unitCapacity;
+        }
+        if (stockQuantity != null) {
+            this.stockQuantity = stockQuantity;
+        }
+    }
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/repository/IngredientDevRepository.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/repository/IngredientDevRepository.java
@@ -1,0 +1,9 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.repository;
+
+import com.inforsion.inforsionserver.domain.ingredient_dev.entity.IngredientDevEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IngredientDevRepository extends JpaRepository<IngredientDevEntity, Integer>, IngredientDevRepositoryCustom {
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/repository/IngredientDevRepositoryCustom.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/repository/IngredientDevRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.repository;
+
+public interface IngredientDevRepositoryCustom {
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/repository/IngredientDevRepositoryImpl.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/repository/IngredientDevRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.repository;
+
+import com.inforsion.inforsionserver.domain.ingredient_dev.entity.IngredientDevEntity;
+import com.inforsion.inforsionserver.domain.ingredient_dev.entity.QIngredientDevEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class IngredientDevRepositoryImpl implements IngredientDevRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsByName(String name) {
+        QIngredientDevEntity ingredient = QIngredientDevEntity.ingredientDevEntity;
+
+        Integer foundId = queryFactory
+                .select(ingredient.id)
+                .from(ingredient)
+                .where(ingredient.name.eq(name))
+                .fetchFirst();
+
+        return foundId != null;
+    }
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/service/IngredientDevService.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient_dev/service/IngredientDevService.java
@@ -1,0 +1,129 @@
+package com.inforsion.inforsionserver.domain.ingredient_dev.service;
+
+import com.inforsion.inforsionserver.domain.ingredient_dev.dto.request.IngredientDevCreateRequest;
+import com.inforsion.inforsionserver.domain.ingredient_dev.dto.request.IngredientDevUpdateRequest;
+import com.inforsion.inforsionserver.domain.ingredient_dev.dto.response.IngredientDevResponse;
+import com.inforsion.inforsionserver.domain.ingredient_dev.entity.IngredientDevEntity;
+import com.inforsion.inforsionserver.domain.ingredient_dev.repository.IngredientDevRepository;
+import com.inforsion.inforsionserver.global.error.code.ErrorCode;
+import com.inforsion.inforsionserver.global.error.exception.BusinessException;
+import com.inforsion.inforsionserver.global.service.S3FileUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IngredientDevService {
+
+    private final IngredientDevRepository ingredientDevRepository;
+    private final S3FileUploadService s3FileUploadService;
+
+    @Transactional
+    public IngredientDevResponse createIngredient(IngredientDevCreateRequest request /*, MultipartFile imageFile */) {
+        if (ingredientDevRepository.existsByName(request.getName())) {
+            throw new BusinessException(ErrorCode.INGREDIENT_ALREADY_EXISTS, "이미 존재하는 재료명입니다.");
+        }
+
+        IngredientDevEntity ingredient = IngredientDevEntity.builder()
+                .name(request.getName())
+                .stockPrice(request.getStockPrice())
+                .unitCapacity(request.getUnitCapacity())
+                .stockQuantity(request.getStockQuantity())
+                .build();
+
+        IngredientDevEntity saved = ingredientDevRepository.save(ingredient);
+
+        // 이미지 업로드는 추후 활성화
+        // if (imageFile != null && !imageFile.isEmpty()) {
+        //     String imageUrl = s3FileUploadService.uploadImageFile(imageFile, "ingredients");
+        //     saved.updateImageUrl(imageUrl);
+        // }
+
+        return IngredientDevResponse.from(saved);
+    }
+
+    @Transactional
+    public IngredientDevResponse updateIngredient(Integer ingredientId, IngredientDevUpdateRequest request) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+
+        if (request.getName() != null && !request.getName().equals(ingredient.getName())) {
+            if (ingredientDevRepository.existsByName(request.getName())) {
+                throw new BusinessException(ErrorCode.INGREDIENT_ALREADY_EXISTS, "이미 존재하는 재료명입니다.");
+            }
+        }
+
+        ingredient.update(
+                request.getName(),
+                request.getStockPrice(),
+                request.getUnitCapacity(),
+                request.getStockQuantity()
+        );
+
+        return IngredientDevResponse.from(ingredient);
+    }
+
+    public IngredientDevResponse getIngredient(Integer ingredientId) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+        return IngredientDevResponse.from(ingredient);
+    }
+
+    @Transactional
+    public void deleteIngredient(Integer ingredientId) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+        // 이미지 파일은 별도 관리 지시에 따라 S3 정리하지 않는다.
+        ingredientDevRepository.delete(ingredient);
+    }
+
+    /**
+     * 이미지 업로드 (기존 이미지가 있다면 유지)
+     */
+    @Transactional
+    public IngredientDevResponse uploadImage(Integer ingredientId, MultipartFile imageFile) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+        String imageUrl = s3FileUploadService.uploadImageFile(imageFile, "ingredients-dev");
+        ingredient.updateImageUrl(imageUrl);
+        return IngredientDevResponse.from(ingredient);
+    }
+
+    /**
+     * 이미지 수정 (기존 이미지를 S3에서 제거 후 새로 업로드)
+     */
+    @Transactional
+    public IngredientDevResponse updateImage(Integer ingredientId, MultipartFile imageFile) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+        s3FileUploadService.deleteFile(ingredient.getImageUrl());
+        String imageUrl = s3FileUploadService.uploadImageFile(imageFile, "ingredients-dev");
+        ingredient.updateImageUrl(imageUrl);
+        return IngredientDevResponse.from(ingredient);
+    }
+
+    /**
+     * 이미지 조회 (URL 반환)
+     */
+    public IngredientDevResponse getImage(Integer ingredientId) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+        if (ingredient.getImageUrl() == null) {
+            throw new BusinessException(ErrorCode.FILE_NOT_FOUND, "해당 재료에 등록된 이미지가 없습니다.");
+        }
+        return IngredientDevResponse.from(ingredient);
+    }
+
+    /**
+     * 이미지 삭제 (S3와 DB 필드 동시 정리)
+     */
+    @Transactional
+    public void deleteImage(Integer ingredientId) {
+        IngredientDevEntity ingredient = getIngredientOrThrow(ingredientId);
+        s3FileUploadService.deleteFile(ingredient.getImageUrl());
+        ingredient.updateImageUrl(null);
+    }
+
+    private IngredientDevEntity getIngredientOrThrow(Integer ingredientId) {
+        return ingredientDevRepository.findById(ingredientId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INGREDIENT_NOT_FOUND,
+                        "재료를 찾을 수 없습니다. ID: " + ingredientId));
+    }
+}


### PR DESCRIPTION


## 관련 이슈 번호
> - 작성자: 김민균
> - 작성 날짜: 2025.11.27

- (이슈 번호 작성) #40 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- 프론트와 연동을 위해 임시로 재료 API 작성

## 📝 작업 상세 내역
### 기능/수정 사항 1
- 재료 등록, 조회, 수정 삭제 API 작성

### 기능/수정 사항 2
- 재료 사진 기능을 위한 사진 등록, 조회, 수정, 삭제 API 작성

## 📌 테스트 및 검증 결과



## 💬 다음 작업 또는 논의 사항
- 기존의 ingredient 엔드포인트 대신에 ingredient_dev로 작성했습니다. 
- 연동 시도 후 오류 나면 말씀해 주세요.
- 데이터베이스 재설계 이후 엔드포인트 변경되면 전달하겠습니다.

## 📎 참고 자료 (선택)
- [참고한 자료 제목](링크)
- [참고한 자료 제목](링크)

## 🐥 리뷰 받고 싶은 포인트(선택)
- 리뷰 받고 싶은 부분이 있다면 작성