### PR TITLE
Fix: 재고, 주문 도메인 문제 수정

### DIFF
--- a/src/main/java/com/inforsion/inforsionserver/domain/inventory/controller/InventoryController.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/inventory/controller/InventoryController.java
@@ -85,7 +85,7 @@ public class InventoryController {
     @DeleteMapping("/{inventoryId}")
     public ResponseEntity<Void> deleteInventory(
             @Parameter(description = "삭제할 재고 ID", required = true, example = "1")
-            @PathVariable("inventoryId") Integer inventoryId
+            @PathVariable Integer inventoryId
     ) {
         inventoryService.deleteInventory(inventoryId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/inforsion/inforsionserver/domain/transaction/controller/TransactionController.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/transaction/controller/TransactionController.java
@@ -16,6 +16,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -40,6 +42,7 @@ public class TransactionController {
     })
     @GetMapping("/{storeId}")
     public ResponseEntity<List<TransactionResponseDto>> getTransactions(
+            @AuthenticationPrincipal Authentication authentication,
             @Parameter(description = "매장 ID", required = true, example = "1")
             @PathVariable Integer storeId,
             @Parameter(description = "거래 유형 (INCOME: 수입, EXPENSE: 지출)", required = true, example = "INCOME")
@@ -49,6 +52,7 @@ public class TransactionController {
             @Parameter(description = "조회 종료 날짜", required = true, example = "2025-08-31T23:59:59")
             @RequestParam LocalDateTime endDate
     ) {
+
         List<TransactionResponseDto> transactions = transactionService.getTransaction(
                 storeId, transactionType, startDate, endDate
         );
@@ -87,8 +91,7 @@ public class TransactionController {
     })
     @DeleteMapping("/{transId}")
     public ResponseEntity<Void> deleteTransaction(
-            @Parameter(description = "삭제할 거래 ID", required = true, example = "1")
-            @PathVariable("transId") Integer transId
+            @PathVariable @Parameter(description = "삭제할 거래 ID", required = true, example = "1") Integer transId
     ) {
         transactionService.deleteTransaction(transId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/inforsion/inforsionserver/domain/transaction/dto/request/TransactionConditionDto.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/transaction/dto/request/TransactionConditionDto.java
@@ -18,6 +18,5 @@ public class TransactionConditionDto {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate endDate; // 마지막 날짜
 
-
     private LocalDate periodType;
 }

--- a/src/main/java/com/inforsion/inforsionserver/domain/transaction/service/TransactionService.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/transaction/service/TransactionService.java
@@ -75,9 +75,7 @@ public class TransactionService {
         entity.setPaymentMethod(requestDto.getPaymentMethod());
         entity.setCostCategory(requestDto.getCostCategory());
 
-        TransactionEntity updated = transactionRepository.save(entity);
-        return toResponseDto(updated);
-
+        return toResponseDto(entity); // dirtychecking 문제때문에 save 를 삭제하였습니다.
     }
 
     /**


### PR DESCRIPTION
Inventory에 겹치는 @pathvariable inventoryId 삭제, transaction 서비스로직 반환 방법 변경

<!-- 
TransectionService의 거래내역 수정에서 발생하는 Dirty Checking 문제를 해결하였습니다. 
-->

## 관련 이슈 번호
> - 작성자: 김나영
> - 작성 날짜: 2026.1.17

- (이슈 번호 작성) #46 

## ✅ 체크리스트
- [ ] 코드가 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경사항에 대한 설명을 작성했습니다.
- [ ] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- Inventory에 겹치는 내용이 있어 삭제하였습니다.

## 📝 작업 상세 내역
### 기능/수정 사항 1
- InventoryController의  @Pathvariable inventoryId 에 경고 문구를 삭제했습니다. 

### 기능/수정 사항 2
- TransactionService에 TransactionEntity updated = transactionRepository.save(entity); return toResponseDto(updated); 코드의 Dirty Checking 문제를 해결했습니다.

## 📌 테스트 및 검증 결과
- 변경 사항을 테스트하거나 검증한 방법, 간단한 결과 설명
- 관련 스크린샷, 영상이 있다면 첨부

## 💬 다음 작업 또는 논의 사항
- 작성한 도메인 수정

## 📎 참고 자료 (선택)


## 🐥 리뷰 받고 싶은 포인트(선택)
- 리뷰 받고 싶은 부분이 있다면 작성