### PR TITLE
Fix: 비활성화된 재료 재등록 가능하도록 수정

### DIFF
--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient/repository/IngredientRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface IngredientRepository extends JpaRepository<IngredientEntity, Integer> {
+public interface IngredientRepository extends JpaRepository<IngredientEntity, Integer>, IngredientRepositoryCustom {
 
     List<IngredientEntity> findByStoreIdAndIsActive(Integer storeId, Boolean isActive);
 

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient/repository/IngredientRepositoryCustom.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient/repository/IngredientRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.inforsion.inforsionserver.domain.ingredient.repository;
+
+import com.inforsion.inforsionserver.domain.ingredient.entity.IngredientEntity;
+
+import java.util.Optional;
+
+public interface IngredientRepositoryCustom {
+
+    Optional<IngredientEntity> findByStoreIdAndNameAndIsActive(Integer storeId, String name, Boolean isActive);
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient/repository/IngredientRepositoryImpl.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient/repository/IngredientRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.inforsion.inforsionserver.domain.ingredient.repository;
+
+import com.inforsion.inforsionserver.domain.ingredient.entity.IngredientEntity;
+import com.inforsion.inforsionserver.domain.ingredient.entity.QIngredientEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class IngredientRepositoryImpl implements IngredientRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<IngredientEntity> findByStoreIdAndNameAndIsActive(Integer storeId, String name, Boolean isActive) {
+        QIngredientEntity ingredient = QIngredientEntity.ingredientEntity;
+
+        IngredientEntity result = queryFactory
+                .selectFrom(ingredient)
+                .where(
+                        ingredient.store.id.eq(storeId),
+                        ingredient.name.eq(name),
+                        ingredient.isActive.eq(isActive)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/inforsion/inforsionserver/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/inforsion/inforsionserver/domain/ingredient/service/IngredientService.java
@@ -12,6 +12,7 @@ import com.inforsion.inforsionserver.global.error.exception.BusinessException;
 import com.inforsion.inforsionserver.global.service.S3FileUploadService;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 // TODO: 페이징 처리가 필요한 경우 주석 해제
@@ -32,6 +33,8 @@ public class IngredientService {
 
     /**
      * 재료 생성
+     * - 같은 이름의 활성화된 재료가 있으면 중복 에러
+     * - 같은 이름의 비활성화된 재료가 있으면 재활성화 후 정보 업데이트
      */
     @Transactional
     public IngredientResponse createIngredient(IngredientCreateRequest request) {
@@ -39,10 +42,29 @@ public class IngredientService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.STORE_NOT_FOUND,
                         "매장을 찾을 수 없습니다. ID: " + request.getStoreId()));
 
-        // 같은 매장에 같은 이름의 재료가 이미 존재하는지 확인
-        if (ingredientRepository.findByStoreIdAndName(request.getStoreId(), request.getName()).isPresent()) {
+        // 같은 매장에 같은 이름의 활성화된 재료가 있는지 확인
+        if (ingredientRepository.findByStoreIdAndNameAndIsActive(request.getStoreId(), request.getName(), true).isPresent()) {
             throw new BusinessException(ErrorCode.INGREDIENT_ALREADY_EXISTS,
                     "이미 존재하는 재료명입니다: " + request.getName());
+        }
+
+        // 비활성화된 같은 이름의 재료가 있으면 재활성화
+        Optional<IngredientEntity> inactiveIngredient = ingredientRepository
+                .findByStoreIdAndNameAndIsActive(request.getStoreId(), request.getName(), false);
+
+        if (inactiveIngredient.isPresent()) {
+            IngredientEntity ingredient = inactiveIngredient.get();
+            ingredient.updateActiveStatus(true);
+            ingredient.update(
+                    request.getName(),
+                    request.getUnit(),
+                    request.getStockPrice(),
+                    request.getUnitCapacity(),
+                    request.getStockQuantity(),
+                    null,
+                    null
+            );
+            return IngredientResponse.from(ingredient);
         }
 
         IngredientEntity ingredient = IngredientEntity.builder()
@@ -93,9 +115,9 @@ public class IngredientService {
     public IngredientResponse updateIngredient(Integer ingredientId, IngredientUpdateRequest request) {
         IngredientEntity ingredient = getIngredientOrThrow(ingredientId);
 
-        // 재료명이 변경되는 경우 중복 체크
+        // 재료명이 변경되는 경우 활성화된 재료 중 중복 체크
         if (request.getName() != null && !request.getName().equals(ingredient.getName())) {
-            if (ingredientRepository.findByStoreIdAndName(ingredient.getStore().getId(), request.getName()).isPresent()) {
+            if (ingredientRepository.findByStoreIdAndNameAndIsActive(ingredient.getStore().getId(), request.getName(), true).isPresent()) {
                 throw new BusinessException(ErrorCode.INGREDIENT_ALREADY_EXISTS,
                         "이미 존재하는 재료명입니다: " + request.getName());
             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
     job:
       enabled: false
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
  
   # 데이터베이스 초기화 설정 (data.sql 비활성화)
   sql:
@@ -204,7 +204,7 @@ spring:
       mode: never                       # SQL 스크립트 실행하지 않음
   batch:
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
     job:
       enabled: false
 


### PR DESCRIPTION
- Ingredient 도메인에 QueryDSL 적용
- 재료 생성 시 활성화된 재료만 중복 체크
- 비활성화된 같은 이름 재료 존재 시 재활성화 후 정보 업데이트
- 재료 수정 시에도 활성화된 재료만 중복 체크
- Spring Batch 스키마 초기화 비활성화 (never)

## 관련 이슈 번호
> - 작성자: 김민균
> - 작성 날짜: 2026.01.27

- (이슈 번호 작성) #43 

## ✅ 체크리스트
- [x] 코드가 정상적으로 작동하는지 확인했습니다.
- [x] 주요 변경사항에 대한 설명을 작성했습니다.
- [x] 코드 스타일 가이드에 따라 코드를 작성했습니다.

## 🧩 작업 내용
- Ingredient repository layer queryDSL 작성
- 삭제된 재료(비활성화된 재료)명과 동일한 재료 등록 시 발생하는 오류 개선
- Spring Batch 오류 개선

## 📝 작업 상세 내역
### 기능/수정 사항 1
- Ingredient repository layer queryDSL 작성
- IngredientRepositoryCustom 작성
- IngredientRepositoryImpl 작성
- 
### 기능/수정 사항 2
- 재료 등록 및 삭제 간 오류 개선
- 삭제된 재료(비활성화된 재료)와 재료명이 동일한 재료 등록 시 기존 재료을 활성화 시키고 사용자가 등록하려는 정보로 업데이트하는 방식으로 개선

## 📌 테스트 및 검증 결과
- 변경 사항을 테스트하거나 검증한 방법, 간단한 결과 설명
- 관련 스크린샷, 영상이 있다면 첨부

## 💬 다음 작업 또는 논의 사항
- 내일 또는 이후에 진행할 예정인 작업
- 추가적인 개선 사항이나 논의가 필요한 내용

## 📎 참고 자료 (선택)
- [참고한 자료 제목](링크)
- [참고한 자료 제목](링크)

## 🐥 리뷰 받고 싶은 포인트(선택)
- 리뷰 받고 싶은 부분이 있다면 작성